### PR TITLE
Update included tiddlywiki version again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,21 @@
 {
     "name": "tiddlydesktop",
-    "version": "0.0.20",
+    "version": "0.0.21",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "tiddlydesktop",
-            "version": "0.0.20",
+            "version": "0.0.21",
             "license": "BSD",
             "dependencies": {
-                "tiddlywiki": "github:Jermolene/TiddlyWiki5"
+                "tiddlywiki": "github:Jermolene/TiddlyWiki5#e64aa6c8f900f1b87b0b29fdea79842f41db9aa8"
             }
         },
         "node_modules/tiddlywiki": {
-            "version": "5.3.0-prerelease",
-            "resolved": "git+ssh://git@github.com/Jermolene/TiddlyWiki5.git#5c5543815b66c95938862a4db71cf6ea36cfe143",
+            "version": "5.3.4-prerelease",
+            "resolved": "git+ssh://git@github.com/Jermolene/TiddlyWiki5.git#e64aa6c8f900f1b87b0b29fdea79842f41db9aa8",
+            "integrity": "sha512-lHDZGCt8nOqWoqiHk6lbkumFsp+P8MgtN54d91CbLwdRCyDuhSPxjROUZ26ijfcZ7arzggxcL09tP/oGZ15BZw==",
             "license": "BSD",
             "bin": {
                 "tiddlywiki": "tiddlywiki.js"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "bundleDependencies": [],
     "license": "BSD",
     "dependencies": {
-        "tiddlywiki": "github:Jermolene/TiddlyWiki5#7d25b1397033fd05ea2483759ced74ee37d18430"
+        "tiddlywiki": "github:Jermolene/TiddlyWiki5#e64aa6c8f900f1b87b0b29fdea79842f41db9aa8"
     }
 }


### PR DESCRIPTION
This time the PR can include `package-lock.json` because the aws-sdk package reference (which was [accidentally added](https://github.com/Jermolene/TiddlyWiki5/issues/8040)) has been removed, so package-lock.json doesn't blow up to a huge size now.