### PR TITLE
Add Linux AppImage build process for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,12 @@ jobs:
         with:
           name: tiddlydesktop-${{ matrix.platform-for-pkg }}-v${{ steps.td-version.outputs.version }}.zip
           path: output/tiddlydesktop-${{ matrix.platform-for-pkg }}-v${{ steps.td-version.outputs.version }}.zip
+      - name: "📤 Uploading Linux AppImage packages..."
+        uses: actions/upload-artifact@v4
+        if: matrix.platform == 'linux'
+        with:
+          name: tiddlydesktop-${{ matrix.platform-for-pkg }}-v${{ steps.td-version.outputs.version }}.AppImage
+          path: output/tiddlydesktop-${{ matrix.platform-for-pkg }}-v${{ steps.td-version.outputs.version }}.AppImage
     outputs:
       td-version: ${{ steps.td-version.outputs.version }}
 
@@ -115,3 +121,4 @@ jobs:
           draft: true
           files: |
             tiddlydesktop-*-v${{ needs.build-and-package.outputs.td-version }}.zip
+            tiddlydesktop-*-v${{ needs.build-and-package.outputs.td-version }}.AppImage

--- a/linux/AppRun
+++ b/linux/AppRun
@@ -1,0 +1,12 @@
+#!/bin/sh
+SELF=$(readlink -f "$0")
+HERE=${SELF%/*}
+export PATH="${HERE}/usr/bin/:${HERE}/usr/sbin/:${HERE}/usr/games/:${HERE}/bin/:${HERE}/sbin/${PATH:+:$PATH}"
+export LD_LIBRARY_PATH="${HERE}/usr/lib/:${HERE}/usr/lib/i386-linux-gnu/:${HERE}/usr/lib/x86_64-linux-gnu/:${HERE}/usr/lib32/:${HERE}/usr/lib64/:${HERE}/lib/:${HERE}/lib/i386-linux-gnu/:${HERE}/lib/x86_64-linux-gnu/:${HERE}/lib32/:${HERE}/lib64/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export PYTHONPATH="${HERE}/usr/share/pyshared/${PYTHONPATH:+:$PYTHONPATH}"
+export XDG_DATA_DIRS="${HERE}/usr/share/${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
+export PERLLIB="${HERE}/usr/share/perl5/:${HERE}/usr/lib/perl5/${PERLLIB:+:$PERLLIB}"
+export GSETTINGS_SCHEMA_DIR="${HERE}/usr/share/glib-2.0/schemas/${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}"
+export QT_PLUGIN_PATH="${HERE}/usr/lib/qt4/plugins/:${HERE}/usr/lib/i386-linux-gnu/qt4/plugins/:${HERE}/usr/lib/x86_64-linux-gnu/qt4/plugins/:${HERE}/usr/lib32/qt4/plugins/:${HERE}/usr/lib64/qt4/plugins/:${HERE}/usr/lib/qt5/plugins/:${HERE}/usr/lib/i386-linux-gnu/qt5/plugins/:${HERE}/usr/lib/x86_64-linux-gnu/qt5/plugins/:${HERE}/usr/lib32/qt5/plugins/:${HERE}/usr/lib64/qt5/plugins/${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}"
+EXEC=$(grep -e '^Exec=.*' "${HERE}"/*.desktop | head -n 1 | cut -d "=" -f 2 | cut -d " " -f 1)
+exec "${EXEC}" "$@"

--- a/linux/tiddlydesktop.desktop
+++ b/linux/tiddlydesktop.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Categories=Utility;TextEditor
+Exec=nw
+Icon=tiddlydesktop
+Name=Tiddly Desktop
+Type=Application
+Version=1.4

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,18 @@ Unzip into a folder and run `TiddlyWiki.app` or `nw.exe` and for linux `nw`
 
 Note that TiddlyDesktop will not work correctly from a Windows UNC network share (eg ``\\MY-SERVER\SHARE\MyFolder``). You should map the network share to a local drive, and run it from there.
 
+## Linux AppImage
+
+Linux releases are also available in the AppImage format. The AppImages are compatible with glibc-based Desktop Linux distributions such as Ubuntu, Fedora, and Arch Linux. The AppImages are _not_ compatible with musl-based Linux distributions such as Alpine Linux, nor are they compatible with Linux server distributions; Server distributions don't provide enough of the required dependencies.
+
+To use an AppImage, your Linux distribution must provide `fusermount3`, which is typically provided in a package named `fuse3`.
+
+Before you can execute an AppImage, you must set the executable permission:
+
+```
+chmod u+x tiddlydesktop-*-v*.AppImage
+```
+
 ## NixOS
 
 To install TiddlyDesktop on NixOS, you first need to add this repo to your `configuration.nix`; Using a `let` expression at the top of the file is a good approach: 


### PR DESCRIPTION
This change adds the necessary CI steps and files to build AppImages for Linux.

The `bld.sh` does not build the AppImages when executed outside of a GitHub action because it installs a number of packages, making it quite intrusive to run on a local PC.

Basically, the process involves installing dependencies, creating a directory with all of the dependencies and Tiddly Desktop itself, and finally using the appimagetool to create the executable AppImage.

I tested the process by sacrificing my fork of the repo and then resetting the master branch when I finished. It was the only way I could realistically test the release process.

I don't have a 32-bit Linux system, so I'm going on faith with the 32-bit AppImage, but I did test the 64-bit AppImage on Ubuntu and Manjaro and it worked :)